### PR TITLE
Add retries when (re)connecting to the stream

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -205,11 +205,18 @@ func MainWithExitCode(factory agent.AgentFactory) int {
 	}
 
 	l.Info("connecting agent to stream")
-
 	streamTimeout := time.Duration(cfg.Stream.Timeout) * time.Second
+	// Set a default interval for the stream retries. A 0 seconds interval is
+	// not allowed.
+	if cfg.Stream.RetryInterval == 0 {
+		cfg.Stream.RetryInterval = 5
+	}
+	sInterval := time.Duration(cfg.Stream.RetryInterval) * time.Second
 	strm, err := stream.New(
 		agentCtx, agentCancel, agt, storage,
 		cfg.Stream.Endpoint, streamTimeout, l,
+		cfg.Stream.Retries,
+		sInterval,
 	)
 	if err != nil {
 		l.WithError(err).Error("error connecting agent to stream")

--- a/config/config.go
+++ b/config/config.go
@@ -43,8 +43,10 @@ type PersistenceConfig struct {
 
 // StreamConfig defines the configuration for the event stream.
 type StreamConfig struct {
-	Endpoint string `toml:"endpoint"`
-	Timeout  int    `toml:"timeout"`
+	Endpoint      string `toml:"endpoint"`
+	Timeout       int    `toml:"timeout"`
+	Retries       int    `toml:"retries"`
+	RetryInterval int    `toml:"retry_interval"`
 }
 
 // UploaderConfig defines the configuration for the results service.

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -10,21 +10,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/danfaizer/gowse"
+	"github.com/sirupsen/logrus"
 
 	agent "github.com/adevinta/vulcan-agent"
 	"github.com/adevinta/vulcan-agent/check"
 )
 
 const (
-	streamPath    = "stream"
 	streamName    = "events"
 	streamTimeout = 2 * time.Second
-
-	pingInterval = 1 * time.Second
-
-	waitTime = 100 * time.Millisecond
+	pingInterval  = 1 * time.Second
+	waitTime      = 100 * time.Millisecond
 )
 
 var (
@@ -169,7 +166,8 @@ func TestStreamActions(t *testing.T) {
 	stor := check.NewMemoryStorage()
 	a := TestAgent{id: knownAgentID, storage: &stor, jobs: make(map[string]check.Job), log: l}
 	agentCtx, agentCancel := context.WithCancel(context.Background())
-	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout, l)
+	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(),
+		streamTimeout, l, 1, time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -301,7 +299,8 @@ func TestStreamConnectTimeout(t *testing.T) {
 	stor := check.NewMemoryStorage()
 	a := TestAgent{id: knownAgentID, storage: &stor, jobs: make(map[string]check.Job), log: l}
 	agentCtx, agentCancel := context.WithCancel(context.Background())
-	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout, l)
+	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(),
+		streamTimeout, l, 1, time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -349,7 +348,8 @@ func TestStreamHandleRegister(t *testing.T) {
 	stor := check.NewMemoryStorage()
 	a := TestAgent{id: knownAgentID, storage: &stor, jobs: make(map[string]check.Job), log: l}
 	agentCtx, agentCancel := context.WithCancel(context.Background())
-	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout, l)
+	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(),
+		streamTimeout, l, 1, time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,7 +405,8 @@ func TestStreamHandleRegisterMalformedMessage(t *testing.T) {
 	stor := check.NewMemoryStorage()
 	a := TestAgent{id: knownAgentID, storage: &stor, jobs: make(map[string]check.Job), log: l}
 	agentCtx, agentCancel := context.WithCancel(context.Background())
-	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout, l)
+	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout,
+		l, 1, time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -461,7 +462,8 @@ func TestStreamHandleRegisterAgentDone(t *testing.T) {
 	stor := check.NewMemoryStorage()
 	a := TestAgent{id: knownAgentID, storage: &stor, jobs: make(map[string]check.Job), log: l}
 	agentCtx, agentCancel := context.WithCancel(context.Background())
-	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout, l)
+	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(),
+		streamTimeout, l, 1, time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -503,7 +505,8 @@ func TestStreamHandleRegisterTimeout(t *testing.T) {
 	a := TestAgent{id: knownAgentID, storage: &stor, jobs: make(map[string]check.Job), log: l}
 	agentCtx, agentCancel := context.WithCancel(context.Background())
 
-	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout, l)
+	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout, l,
+		1, time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -541,7 +544,8 @@ func TestStreamReconnect(t *testing.T) {
 	stor := check.NewMemoryStorage()
 	a := TestAgent{id: knownAgentID, storage: &stor, jobs: make(map[string]check.Job), log: l}
 	agentCtx, agentCancel := context.WithCancel(context.Background())
-	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout, l)
+	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout,
+		l, 1, time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -638,7 +642,8 @@ func TestStreamDisconnect(t *testing.T) {
 	stor := check.NewMemoryStorage()
 	a := TestAgent{id: knownAgentID, storage: &stor, jobs: make(map[string]check.Job), log: l}
 	agentCtx, agentCancel := context.WithCancel(context.Background())
-	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout, l)
+	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout, l,
+		2, time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -721,7 +726,8 @@ func TestStreamCancel(t *testing.T) {
 	stor := check.NewMemoryStorage()
 	a := TestAgent{id: knownAgentID, storage: &stor, jobs: make(map[string]check.Job), log: l}
 	agentCtx, agentCancel := context.WithCancel(context.Background())
-	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout, l)
+	s, err := New(agentCtx, agentCancel, &a, &stor, wsURL.String(), streamTimeout, l,
+		1, time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stream/websocket.go
+++ b/stream/websocket.go
@@ -1,0 +1,67 @@
+package stream
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/lestrrat-go/backoff"
+	"github.com/sirupsen/logrus"
+)
+
+// WSDialerWithRetries provides retries with backoff and jitter
+// when initiating a connection to a websocket.
+type WSDialerWithRetries struct {
+	*websocket.Dialer
+	p backoff.Policy
+	l *logrus.Entry
+}
+
+// NewWSDialerWithRetries creates a WSDialer with the given retries parameters.
+func NewWSDialerWithRetries(dialer *websocket.Dialer, log *logrus.Entry, retries int, interval time.Duration) *WSDialerWithRetries {
+	p := backoff.NewExponential(
+		backoff.WithInterval(interval),
+		backoff.WithJitterFactor(0.05),
+		backoff.WithMaxRetries(retries),
+	)
+	return &WSDialerWithRetries{dialer, p, log}
+}
+
+// Dial wraps the dial function of the websocket dialer adding retries
+// functionality.
+func (ws *WSDialerWithRetries) Dial(urlStr string, requestHeader http.Header) (*websocket.Conn, *http.Response, error) {
+	var (
+		conn *websocket.Conn
+		resp *http.Response
+	)
+	err := withBackoff(ws.p, ws.l.WithField("websocket", "dial"), func() error {
+		var err error
+		conn, resp, err = websocket.DefaultDialer.Dial(urlStr, requestHeader)
+		return err
+	})
+	return conn, resp, err
+}
+
+func withBackoff(p backoff.Policy, l *logrus.Entry, exec func() error) error {
+	var err error
+	retry, cancel := p.Start(context.Background())
+	defer cancel()
+	n := 0
+	for {
+		err = exec()
+		if err == nil {
+			return nil
+		}
+		select {
+		case <-retry.Done():
+			l.WithField("retry_number", n).Error("backoff finished unable to perform operation")
+			return err
+		case <-retry.Next():
+			n++
+			if n > 1 {
+				l.WithField("retry_number", n-1).Error("backoff fired. Retrying")
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR modify the way the agent connects and reconnects to the stream component. Concretely the agent would not shutdown when it loses the connection to the stream during a defined period of time.

To do that the agent now uses retries with exponential backoff and jitter whenever it tries to open a web socket connection to the stream. The number of retries and the period between retries can be configured using the corresponding parameters in the stream configuration section. 