### PR TITLE
Allow custom AWS SQS endpoint

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -134,8 +134,7 @@ func MainWithExitCode(factory agent.AgentFactory) int {
 
 	jobs := scheduler.NewJobScheduler(cfg.Scheduler.ConcurrentJobs, capacityChan, pauseChan)
 
-	pollingInterval := time.Duration(cfg.SQS.PollingInterval) * time.Second
-	sqs, err := queue.NewSQSQueueManager(jobqueueARN, pollingInterval, cfg.SQS.Endpoint, cfg.SQS.Region, capacityChan, pauseChan)
+	sqs, err := queue.NewSQSQueueManager(jobqueueARN, cfg.SQS, capacityChan, pauseChan)
 	if err != nil {
 		l.WithError(err).Error("error connecting agent to SQS queue")
 		return 1

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -135,7 +135,7 @@ func MainWithExitCode(factory agent.AgentFactory) int {
 	jobs := scheduler.NewJobScheduler(cfg.Scheduler.ConcurrentJobs, capacityChan, pauseChan)
 
 	pollingInterval := time.Duration(cfg.SQS.PollingInterval) * time.Second
-	sqs, err := queue.NewSQSQueueManager(jobqueueARN, pollingInterval, capacityChan, pauseChan)
+	sqs, err := queue.NewSQSQueueManager(jobqueueARN, pollingInterval, cfg.SQS.Endpoint, cfg.SQS.Region, capacityChan, pauseChan)
 	if err != nil {
 		l.WithError(err).Error("error connecting agent to SQS queue")
 		return 1

--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ type SQSConfig struct {
 	PollingInterval int    `toml:"polling_interval"`
 	Endpoint        string `toml:"endpoint"`
 	Region          string `toml:"region"`
+	QueueName       string `toml:"queue_name"`
 }
 
 // APIConfig defines the configuration for the agent API.

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,9 @@ type UploaderConfig struct {
 
 // SQSConfig defines the configuration for the SQS queue.
 type SQSConfig struct {
-	PollingInterval int `toml:"polling_interval"`
+	PollingInterval int    `toml:"polling_interval"`
+	Endpoint        string `toml:"endpoint"`
+	Region          string `toml:"region"`
 }
 
 // APIConfig defines the configuration for the agent API.

--- a/docker/agent.go
+++ b/docker/agent.go
@@ -62,14 +62,16 @@ func NewAgent(ctx context.Context, cancel context.CancelFunc, id string, storage
 
 	cli := docker.NewClient(envCli)
 
-	err = cli.Login(
-		ctx,
-		cfg.Runtime.Docker.Registry.Server,
-		cfg.Runtime.Docker.Registry.User,
-		cfg.Runtime.Docker.Registry.Pass,
-	)
-	if err != nil {
-		return &Agent{}, err
+	if cfg.Runtime.Docker.Registry.Server != "" {
+		err = cli.Login(
+			ctx,
+			cfg.Runtime.Docker.Registry.Server,
+			cfg.Runtime.Docker.Registry.User,
+			cfg.Runtime.Docker.Registry.Pass,
+		)
+		if err != nil {
+			return &Agent{}, err
+		}
 	}
 	var addr string
 	if cfg.API.Host != "" {

--- a/docker/agent.go
+++ b/docker/agent.go
@@ -62,6 +62,8 @@ func NewAgent(ctx context.Context, cancel context.CancelFunc, id string, storage
 
 	cli := docker.NewClient(envCli)
 
+	// If registry server is not provided we assume public
+	// DockerHub is being used without authenticate.
 	if cfg.Runtime.Docker.Registry.Server != "" {
 		err = cli.Login(
 			ctx,

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/adevinta/dockerutils v0.0.0-20190826104125-915f26bde8e5
 	github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff
-	github.com/aws/aws-sdk-go v1.25.30
+	github.com/aws/aws-sdk-go v1.30.11
 	github.com/danfaizer/gowse v0.0.0-20190820120814-8f5010580eaf
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1
@@ -19,5 +19,4 @@ require (
 	github.com/lestrrat-go/backoff v1.0.0
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/sirupsen/logrus v1.4.2
-	golang.org/x/net v0.0.0-20191108063844-7e6e90b9ea88 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff h1:ZazuZSOf
 github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff/go.mod h1:GtAon6TymHFTOPwRdR7SHun/TSM1kyPMQYXxGLTR8eQ=
 github.com/aws/aws-sdk-go v1.25.30 h1:I9qj6zW3mMfsg91e+GMSN/INcaX9tTFvr/l/BAHKaIY=
 github.com/aws/aws-sdk-go v1.25.30/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.30.11 h1:bJoa1QGyyAV4COx1SXpf+LElFVVnOreG6KM0jIxwZq0=
+github.com/aws/aws-sdk-go v1.30.11/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/danfaizer/gowse v0.0.0-20190820120814-8f5010580eaf h1:IUlazfDHc/6IdB0PJfJBjQLpod7T2TMVrFSlLfIJquc=
 github.com/danfaizer/gowse v0.0.0-20190820120814-8f5010580eaf/go.mod h1:1EfsRigh2c4c0CCHcPw/jxPW4V05tBIrtsi2dRSur1I=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -22,10 +24,13 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
@@ -36,6 +41,7 @@ github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2i
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
@@ -44,9 +50,11 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20191108063844-7e6e90b9ea88 h1:Duq71GDCs3Cs8n6cRINv6SutZHHvYwzL28LBv73RiNU=
 golang.org/x/net v0.0.0-20191108063844-7e6e90b9ea88/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2i
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
@@ -54,6 +55,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20191108063844-7e6e90b9ea88 h1:Duq71GDCs3Cs8n6cRINv6SutZHHvYwzL28LBv73RiNU=
 golang.org/x/net v0.0.0-20191108063844-7e6e90b9ea88/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
- Modify Agent allowing create new Agent without login to a specific Docker registry if server is not defined.
- Modify Config and SQS Queue Manager to allow custom AWS endpoint and region.