### PR TITLE
Add support for inconclusive check status

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -237,8 +237,8 @@ func (a *API) handleCheckUpdate(w http.ResponseWriter, r *http.Request, ps httpr
 		l.Info("check reported as aborted")
 	case check.StatusFailed:
 		l.Warn("check reported as failed")
-	case check.StatusUnreachable:
-		l.Warn("check reported as unreachable")
+	case check.StatusInconclusive:
+		l.Warn("check reported as inconclusive")
 	default:
 		err = errors.New("error updating check to unknown status")
 		l.WithFields(logrus.Fields{

--- a/api/api.go
+++ b/api/api.go
@@ -8,14 +8,14 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/adevinta/vulcan-agent"
+	agent "github.com/adevinta/vulcan-agent"
 	"github.com/adevinta/vulcan-agent/check"
 	"github.com/adevinta/vulcan-agent/persistence"
 	"github.com/adevinta/vulcan-agent/results"
 	"github.com/adevinta/vulcan-agent/scheduler"
 
-	"github.com/sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
+	"github.com/sirupsen/logrus"
 )
 
 // API represents Agent API
@@ -237,6 +237,8 @@ func (a *API) handleCheckUpdate(w http.ResponseWriter, r *http.Request, ps httpr
 		l.Info("check reported as aborted")
 	case check.StatusFailed:
 		l.Warn("check reported as failed")
+	case check.StatusUnreachable:
+		l.Warn("check reported as unreachable")
 	default:
 		err = errors.New("error updating check to unknown status")
 		l.WithFields(logrus.Fields{

--- a/check/check.go
+++ b/check/check.go
@@ -26,7 +26,7 @@ const (
 	StatusUnreachable = "UNREACHABLE"
 )
 
-var terminalStatuses = []string{StatusAborted, StatusKilled, StatusFailed, StatusFinished, StatusMalformed, StatusTimeout}
+var terminalStatuses = []string{StatusAborted, StatusKilled, StatusFailed, StatusFinished, StatusMalformed, StatusTimeout, StatusUnreachable}
 
 // JobParams stores the information necessary to create a new check job.
 type JobParams struct {

--- a/check/check.go
+++ b/check/check.go
@@ -12,21 +12,21 @@ import (
 
 // Constants defining the possible statuses for a check job.
 const (
-	StatusCreated     = "CREATED"
-	StatusQueued      = "QUEUED"
-	StatusAssigned    = "ASSIGNED"
-	StatusRunning     = "RUNNING"
-	StatusTimeout     = "TIMEOUT"
-	StatusAborted     = "ABORTED"
-	StatusPurging     = "PURGING"
-	StatusKilled      = "KILLED"
-	StatusFailed      = "FAILED"
-	StatusFinished    = "FINISHED"
-	StatusMalformed   = "MALFORMED"
-	StatusUnreachable = "UNREACHABLE"
+	StatusCreated      = "CREATED"
+	StatusQueued       = "QUEUED"
+	StatusAssigned     = "ASSIGNED"
+	StatusRunning      = "RUNNING"
+	StatusTimeout      = "TIMEOUT"
+	StatusAborted      = "ABORTED"
+	StatusPurging      = "PURGING"
+	StatusKilled       = "KILLED"
+	StatusFailed       = "FAILED"
+	StatusFinished     = "FINISHED"
+	StatusMalformed    = "MALFORMED"
+	StatusInconclusive = "INCONCLUSIVE"
 )
 
-var terminalStatuses = []string{StatusAborted, StatusKilled, StatusFailed, StatusFinished, StatusMalformed, StatusTimeout, StatusUnreachable}
+var terminalStatuses = []string{StatusAborted, StatusKilled, StatusFailed, StatusFinished, StatusMalformed, StatusTimeout, StatusInconclusive}
 
 // JobParams stores the information necessary to create a new check job.
 type JobParams struct {

--- a/check/check.go
+++ b/check/check.go
@@ -12,17 +12,18 @@ import (
 
 // Constants defining the possible statuses for a check job.
 const (
-	StatusCreated   = "CREATED"
-	StatusQueued    = "QUEUED"
-	StatusAssigned  = "ASSIGNED"
-	StatusRunning   = "RUNNING"
-	StatusTimeout   = "TIMEOUT"
-	StatusAborted   = "ABORTED"
-	StatusPurging   = "PURGING"
-	StatusKilled    = "KILLED"
-	StatusFailed    = "FAILED"
-	StatusFinished  = "FINISHED"
-	StatusMalformed = "MALFORMED"
+	StatusCreated     = "CREATED"
+	StatusQueued      = "QUEUED"
+	StatusAssigned    = "ASSIGNED"
+	StatusRunning     = "RUNNING"
+	StatusTimeout     = "TIMEOUT"
+	StatusAborted     = "ABORTED"
+	StatusPurging     = "PURGING"
+	StatusKilled      = "KILLED"
+	StatusFailed      = "FAILED"
+	StatusFinished    = "FINISHED"
+	StatusMalformed   = "MALFORMED"
+	StatusUnreachable = "UNREACHABLE"
 )
 
 var terminalStatuses = []string{StatusAborted, StatusKilled, StatusFailed, StatusFinished, StatusMalformed, StatusTimeout}


### PR DESCRIPTION
This PR adds support in vulcan-agent for the new `INCONCLUSIVE` status check.
This new status is a terminal status and should be the one reported when the scan of the asset was not able to be performed correctly. E.g.: Asset was unreachable.

Related with:
[vulcan-check-sdk #12](https://github.com/adevinta/vulcan-check-sdk/pull/12)
[vulcan-persistence #51](https://github.com/adevinta/vulcan-persistence/pull/51)