### PR TITLE
Include asset type into check execution context

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -15,7 +15,7 @@ const (
 	ChecktypeNameVar    = "VULCAN_CHECKTYPE_NAME"
 	ChecktypeVersionVar = "VULCAN_CHECKTYPE_VERSION"
 	CheckTargetVar      = "VULCAN_CHECK_TARGET"
-	CheckTargetTypeVar  = "VULCAN_CHECK_TARGET_TYPE"
+	CheckAssetTypeVar   = "VULCAN_CHECK_ASSET_TYPE"
 	CheckOptionsVar     = "VULCAN_CHECK_OPTIONS"
 	CheckLogLevelVar    = "VULCAN_CHECK_LOG_LVL"
 

--- a/agent.go
+++ b/agent.go
@@ -15,6 +15,7 @@ const (
 	ChecktypeNameVar    = "VULCAN_CHECKTYPE_NAME"
 	ChecktypeVersionVar = "VULCAN_CHECKTYPE_VERSION"
 	CheckTargetVar      = "VULCAN_CHECK_TARGET"
+	CheckTargetTypeVar  = "VULCAN_CHECK_TARGET_TYPE"
 	CheckOptionsVar     = "VULCAN_CHECK_OPTIONS"
 	CheckLogLevelVar    = "VULCAN_CHECK_LOG_LVL"
 

--- a/check/check.go
+++ b/check/check.go
@@ -35,8 +35,8 @@ type JobParams struct {
 	ScanStartTime time.Time         `json:"start_time"`    // Required
 	Image         string            `json:"image"`         // Required
 	Target        string            `json:"target"`        // Required
-	TargetType    string            `json:"target_type"`   // Required
 	Timeout       int               `json:"timeout"`       // Required
+	AssetType     string            `json:"assettype"`     // Optional
 	Options       string            `json:"options"`       // Optional
 	RequiredVars  []string          `json:"required_vars"` // Optional
 	Metadata      map[string]string `json:"metadata"`      // Optional

--- a/check/check.go
+++ b/check/check.go
@@ -35,6 +35,7 @@ type JobParams struct {
 	ScanStartTime time.Time         `json:"start_time"`    // Required
 	Image         string            `json:"image"`         // Required
 	Target        string            `json:"target"`        // Required
+	TargetType    string            `json:"target_type"`   // Required
 	Timeout       int               `json:"timeout"`       // Required
 	Options       string            `json:"options"`       // Optional
 	RequiredVars  []string          `json:"required_vars"` // Optional

--- a/check/storage.go
+++ b/check/storage.go
@@ -202,18 +202,8 @@ func (m *MemoryStorage) NewJob(parent context.Context, params JobParams, log *lo
 	}
 
 	job := Job{
-		JobParams: JobParams{
-			ScanID:        params.ScanID,
-			ScanStartTime: params.ScanStartTime,
-			CheckID:       params.CheckID,
-			Target:        params.Target,
-			Options:       params.Options,
-			RequiredVars:  params.RequiredVars,
-			Image:         params.Image,
-			Timeout:       params.Timeout,
-			Metadata:      params.Metadata,
-		},
-		log: log,
+		JobParams: params,
+		log:       log,
 	}
 
 	job.Ctx, job.Cancel = context.WithCancel(parent)

--- a/docker/agent.go
+++ b/docker/agent.go
@@ -306,6 +306,7 @@ func (a *Agent) getRunConfig(job check.Job) docker.RunConfig {
 				fmt.Sprintf("%s=%s", agent.ChecktypeNameVar, checktypeName),
 				fmt.Sprintf("%s=%s", agent.ChecktypeVersionVar, checktypeVersion),
 				fmt.Sprintf("%s=%s", agent.CheckTargetVar, job.Target),
+				fmt.Sprintf("%s=%s", agent.CheckTargetTypeVar, job.TargetType),
 				fmt.Sprintf("%s=%s", agent.CheckOptionsVar, job.Options),
 				fmt.Sprintf("%s=%s", agent.CheckLogLevelVar, logLevel),
 				fmt.Sprintf("%s=%s", agent.AgentAddressVar, a.addr),

--- a/docker/agent.go
+++ b/docker/agent.go
@@ -306,7 +306,7 @@ func (a *Agent) getRunConfig(job check.Job) docker.RunConfig {
 				fmt.Sprintf("%s=%s", agent.ChecktypeNameVar, checktypeName),
 				fmt.Sprintf("%s=%s", agent.ChecktypeVersionVar, checktypeVersion),
 				fmt.Sprintf("%s=%s", agent.CheckTargetVar, job.Target),
-				fmt.Sprintf("%s=%s", agent.CheckTargetTypeVar, job.TargetType),
+				fmt.Sprintf("%s=%s", agent.CheckAssetTypeVar, job.AssetType),
 				fmt.Sprintf("%s=%s", agent.CheckOptionsVar, job.Options),
 				fmt.Sprintf("%s=%s", agent.CheckLogLevelVar, logLevel),
 				fmt.Sprintf("%s=%s", agent.AgentAddressVar, a.addr),

--- a/kubernetes/agent.go
+++ b/kubernetes/agent.go
@@ -213,6 +213,7 @@ func (a *Agent) getEnvVars(job check.Job) []string {
 			"--env", fmt.Sprintf("%s=%s", agent.ChecktypeNameVar, checktypeName),
 			"--env", fmt.Sprintf("%s=%s", agent.ChecktypeVersionVar, checktypeVersion),
 			"--env", fmt.Sprintf("%s=%s", agent.CheckTargetVar, job.Target),
+			"--env", fmt.Sprintf("%s=%s", agent.CheckTargetTypeVar, job.TargetType),
 			"--env", fmt.Sprintf("%s=%s", agent.CheckOptionsVar, job.Options),
 			"--env", fmt.Sprintf("%s=%s", agent.CheckLogLevelVar, logLevel),
 			"--env", fmt.Sprintf("%s=%s", agent.AgentAddressVar, a.addr),

--- a/kubernetes/agent.go
+++ b/kubernetes/agent.go
@@ -213,7 +213,7 @@ func (a *Agent) getEnvVars(job check.Job) []string {
 			"--env", fmt.Sprintf("%s=%s", agent.ChecktypeNameVar, checktypeName),
 			"--env", fmt.Sprintf("%s=%s", agent.ChecktypeVersionVar, checktypeVersion),
 			"--env", fmt.Sprintf("%s=%s", agent.CheckTargetVar, job.Target),
-			"--env", fmt.Sprintf("%s=%s", agent.CheckTargetTypeVar, job.TargetType),
+			"--env", fmt.Sprintf("%s=%s", agent.CheckAssetTypeVar, job.AssetType),
 			"--env", fmt.Sprintf("%s=%s", agent.CheckOptionsVar, job.Options),
 			"--env", fmt.Sprintf("%s=%s", agent.CheckLogLevelVar, logLevel),
 			"--env", fmt.Sprintf("%s=%s", agent.AgentAddressVar, a.addr),


### PR DESCRIPTION
This PR modifies the vulcan-agent to parse the `TargetType` from the queue message body. This target type is included in the `Job params` and eventually in the check execution context through a new environment variable.