### PR TITLE
Fix issue agent exiting prematurely

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -48,7 +48,7 @@ type CheckStateUpdater interface {
 // about agent stats that it exposed to the outside world.
 type AgentStats interface {
 	ChecksRunning() int
-	LastMessageReceived() time.Time
+	LastMessageReceived() *time.Time
 }
 
 // API defines the methods of the API that the agent exposes to the outside.
@@ -112,5 +112,5 @@ func (a *API) CheckUpdate(c CheckState) error {
 func (a *API) Stats() (Stats, error) {
 	last := a.agentStats.LastMessageReceived()
 	n := a.agentStats.ChecksRunning()
-	return Stats{LastMessageReceived: &last, ChecksRunning: n}, nil
+	return Stats{LastMessageReceived: last, ChecksRunning: n}, nil
 }

--- a/backend/docker/docker.go
+++ b/backend/docker/docker.go
@@ -20,10 +20,7 @@ import (
 	"github.com/adevinta/vulcan-agent/log"
 )
 
-const (
-	defaultDockerIfaceName = "docker0"
-	abortTimeout           = 5 * time.Second //seconds
-)
+const abortTimeout = 5 * time.Second
 
 // ErrConExitUnexpected is returned by the docker backend when a
 // container was killed externally while running.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -111,20 +111,27 @@ func MainWithExitCode(bc BackendCreator) int {
 	// Setup metrics.
 	metrics := metrics.NewMetrics(l, cfg.DataDog, jrunner)
 
+	ctxqr, cancelqr := context.WithCancel(context.Background())
+
 	endpoint = cfg.Stream.Endpoint
 	stream := stream.New(l, metrics, re, endpoint)
-	sCtx, cancelStream := context.WithCancel(context.Background())
-	streamDone, err := stream.ListenAndProcess(sCtx)
+	streamDone, err := stream.ListenAndProcess(ctxqr)
 	if err != nil {
 		l.Errorf("error starting stream: %+v", err)
-		cancelStream()
+		cancelqr()
 		return 1
 	}
 
-	qr, err := sqs.NewReader(l, cfg.SQSReader, jrunner)
+	var maxTimeNoMsg *time.Duration
+	if cfg.Agent.MaxNoMsgsInterval > 0 {
+		t := time.Duration(cfg.Agent.MaxNoMsgsInterval) * time.Second
+		maxTimeNoMsg = &t
+	}
+
+	qr, err := sqs.NewReader(l, cfg.SQSReader, maxTimeNoMsg, jrunner)
 	if err != nil {
 		l.Errorf("error starting SQSReader: %+v", err)
-		cancelStream()
+		cancelqr()
 		return 1
 	}
 	stats := struct {
@@ -148,17 +155,7 @@ func MainWithExitCode(bc BackendCreator) int {
 		close(httpDone)
 	}()
 
-	ctxqr, cancelqr := context.WithCancel(context.Background())
 	qrdone := qr.StartReading(ctxqr)
-
-	maxTimeNoMsg := time.Duration(cfg.Agent.MaxNoMsgsInterval) * time.Second
-	qStopper := queue.ReaderStopper{
-		R:       qr,
-		MaxTime: maxTimeNoMsg,
-	}
-
-	stopperDone := qStopper.Track(ctxqr)
-
 	metricsDone := metrics.StartPolling(ctxqr)
 
 	l.Infof("agent running on address %s", srv.Addr)
@@ -168,30 +165,22 @@ func MainWithExitCode(bc BackendCreator) int {
 	select {
 	case <-sig:
 		// Signal the sqs queue reader to stop reading messages from the queue.
-		l.Infof("SIG received, stoping sqs queue reader")
-		cancelqr()
-	case err = <-stopperDone:
-		msg := "shutting down agent because more than %+d seconds elapsed without messages read"
-		l.Infof(msg, maxTimeNoMsg.Seconds())
+		l.Infof("SIG received, stoping agent")
 		cancelqr()
 	case err = <-httpDone:
-		l.Errorf("error running agent http api %+v", err)
+		l.Errorf("error running the the agent api %+v", err)
+		cancelqr()
+	case err = <-qrdone:
 		cancelqr()
 	}
 
-	l.Infof("wating for the checks to finish before stoping the agent")
-
-	// Wait for the queue stopper to finish.
-	err = <-stopperDone
-	if err != nil && !errors.Is(err, context.Canceled) {
-		cancelStream()
-		l.Errorf("error stopping the reader tracker %+v", err)
-	}
 	// Wait for all the pending jobs to finish.
-	err = <-qrdone
-	if err != nil && !errors.Is(err, context.Canceled) {
-		cancelStream()
-		l.Errorf("error stopping agent %+v", err)
+	if !errors.Is(err, queue.ErrMaxTimeNoRead) {
+		l.Infof("waiting for the checks to finish before stoping the agent")
+		err = <-qrdone
+		if err != nil && !errors.Is(err, context.Canceled) {
+			l.Errorf("error waiting for the checks to finish %+v", err)
+		}
 	}
 
 	// Wait for the metrics to stop polling.
@@ -200,18 +189,14 @@ func MainWithExitCode(bc BackendCreator) int {
 	// Stop listening for api calls.
 	err = srv.Shutdown(context.Background())
 	if err != nil {
-		cancelStream()
 		l.Errorf("error stoping http server: %+v", err)
 		return 1
 	}
 	err = <-httpDone
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
-		cancelStream()
 		l.Errorf("http server stopped with error: %+v", err)
 		return 1
 	}
-	// Stop the stream.
-	cancelStream()
 	// Wait for the stream to finish.
 	err = <-streamDone
 	if err != nil && !errors.Is(err, context.Canceled) {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -7,13 +7,9 @@ import (
 )
 
 var (
-	// ReaderStopperPollPeriod defines the time period a ReaderStopper will get the
-	// last time a Reader received a message.
-	ReaderStopperPollPeriod = 5
-
-	// ErrMaxTimeNoMessageExceeded is returned in the Track channel when the
-	// maximun time without message has been elapsed.
-	ErrMaxTimeNoMessageExceeded = errors.New("max time without messages read exceeded")
+	// ErrMaxTimeNoRead is returned by a reader when more than the specified
+	// amount of seconds has passed without getting a message from the queue.
+	ErrMaxTimeNoRead = errors.New("maximun allowed for reading a message exceeded")
 )
 
 // MessageProcessor defines the methods needed by a queue reader implementation
@@ -27,62 +23,10 @@ type MessageProcessor interface {
 // implementations must fullfil.
 type Reader interface {
 	StartReading(ctx context.Context) <-chan error
-	LastMessageReceived() time.Time
+	LastMessageReceived() *time.Time
 }
 
 // Writer defines the functions that a queue writer must implement.
 type Writer interface {
 	Write(body string) error
-}
-
-// ReaderStopper tracks a the time the last message was received by a queue reader.
-// If that time is greater than the specified period, the ReaderStopper calls the passed
-// in function.
-type ReaderStopper struct {
-	R       Reader
-	MaxTime time.Duration
-}
-
-// Track continuously reads the LastMessageReceived from the Reader stored in
-// the receiver. If the that time exceeds the period defined in
-// ReaderStopperPollPeriod the channel returned by the function will contain the
-// a nil value. The function will also stop tracking the last message received
-// if if the passed in context is canceled. In that case the returned channel
-// will contain the value returned by ctx.Err().
-func (rs ReaderStopper) Track(ctx context.Context) <-chan error {
-	var done = make(chan error, 1)
-	// A value of 0 means do not track the LastMessageReceived time at all.
-	if rs.MaxTime == time.Duration(0) {
-		go func() {
-			<-ctx.Done()
-			done <- ctx.Err()
-			close(done)
-		}()
-		return done
-	}
-	pollTime := time.Duration(ReaderStopperPollPeriod) * time.Second
-	pollTimer := time.NewTimer(pollTime)
-	go func() {
-		var err error
-		defer func() {
-			done <- err
-			close(done)
-		}()
-	loop:
-		for {
-			select {
-			case <-pollTimer.C:
-				last := rs.R.LastMessageReceived()
-				now := time.Now()
-				if now.Sub(last) > rs.MaxTime {
-					break loop
-				}
-				pollTimer.Reset(pollTime)
-			case <-ctx.Done():
-				err = ctx.Err()
-				break loop
-			}
-		}
-	}()
-	return done
 }

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -7,9 +7,10 @@ import (
 )
 
 var (
-	// ErrMaxTimeNoRead is returned by a reader when more than the specified
-	// amount of seconds has passed without getting a message from the queue.
-	ErrMaxTimeNoRead = errors.New("maximun allowed for reading a message exceeded")
+	// ErrMaxTimeNoRead is returned by a queue reader when there were no
+	// messages available in the queue for more than the configured amount of
+	// time.
+	ErrMaxTimeNoRead = errors.New("no messages available in the queue for more than the max time")
 )
 
 // MessageProcessor defines the methods needed by a queue reader implementation

--- a/resources/example.toml
+++ b/resources/example.toml
@@ -5,7 +5,7 @@ log_level = "debug"
 log_file = "agent.log"
 concurrent_jobs = 5
 # Maximum number of seconds the agent will remain active without received any
-# message.
+# message. 0 means the agent will remain active forever.
 max_no_msgs_interval = 0
 
 [uploader]

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -13,7 +13,7 @@ import (
 var (
 	// ReadTimeout specifies the time, in seconds, the streams wait for reading
 	// the next message.
-	ReadTimeout = 15
+	ReadTimeout = 5
 )
 
 type readMessageResult struct {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"time"
 
@@ -84,7 +85,9 @@ LOOP:
 		case readRes := <-msgRead:
 			err = readRes.Error
 			if err != nil {
-				s.l.Errorf("error reading message from the stream: %s", err)
+				if !errIsTimeout(err) {
+					s.l.Errorf("error reading message from the stream: %s", err)
+				}
 				conn, err = s.reconnect(ctx)
 				if err != nil {
 					break LOOP
@@ -149,4 +152,11 @@ func (s *Stream) processMessage(msg Message) {
 	default:
 		s.l.Errorf("error unknown message received: %+v", msg)
 	}
+}
+
+func errIsTimeout(err error) bool {
+	if err, ok := err.(net.Error); ok && err.Timeout() {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
This PR fixes  an issue in the agent that was causing the agent to exit prematurely.
Concretely, the ReadStopper struct was in change of tracking when the sqs reader didn't read a message from the queue for too long, and consequently it forced the reader to stop trying to reading messages, wait for all the currently processing message to finish and exit the agent. The problem was that if the agent was processing the maximum allowed number of messages, the ReadStopper will still track the last read message time, so the agent was stopping reading messages even when more messages were available to read from queue. I removed the ReadStopper component and is the reader struct that now tracks for how long it is trying to read messages from the queue (so it only measures the time when is really trying to read messages no while is locked because it's already processing the max number of messages), is that time is more than the maximum allowed **and the agent is not processing any message** then the reader, therefore the agent, stops running.

The PR also contains other minor improvements:
- Removal of some unused vars.
- Simplify the creation of the context in the root command.
- Improve some errors and debug messages
