### PR TITLE
Limit the maximum amount of times a message can be processed

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -102,8 +102,9 @@ func MainWithExitCode(bc BackendCreator) int {
 	}
 
 	runnerCfg := jobrunner.RunnerConfig{
-		MaxTokens:      cfg.Agent.ConcurrentJobs,
-		DefaultTimeout: cfg.Agent.Timeout,
+		MaxTokens:              cfg.Agent.ConcurrentJobs,
+		DefaultTimeout:         cfg.Agent.Timeout,
+		MaxProcessMessageTimes: cfg.Agent.MaxProcessMessageTimes,
 	}
 
 	jrunner := jobrunner.New(l, b, updater, abortedChecks, runnerCfg)

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,8 @@ type AgentConfig struct {
 	ConcurrentJobs int    `toml:"concurrent_jobs"`
 	// MaxMsgsInterval defines the maximun time, in seconds, the agent can
 	// running without reading any message from the queue.
-	MaxNoMsgsInterval int `toml:"max_no_msgs_interval"`
+	MaxNoMsgsInterval      int `toml:"max_no_msgs_interval"`
+	MaxProcessMessageTimes int `toml:"max_message_processed_times"`
 }
 
 // StreamConfig defines the configuration for the event stream.

--- a/jobrunner/runner_test.go
+++ b/jobrunner/runner_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/adevinta/vulcan-agent/backend"
 	"github.com/adevinta/vulcan-agent/log"
+	"github.com/adevinta/vulcan-agent/queue"
 	"github.com/adevinta/vulcan-agent/stateupdater"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
@@ -108,7 +109,7 @@ func TestRunner_ProcessMessage(t *testing.T) {
 		defaultTimeout time.Duration
 	}
 	type args struct {
-		msg   string
+		msg   queue.Message
 		token interface{}
 	}
 	tests := []struct {
@@ -147,7 +148,9 @@ func TestRunner_ProcessMessage(t *testing.T) {
 				CheckUpdater:   &inMemChecksUpdater{},
 			},
 			args: args{
-				msg:   string(mustMarshal(runJobFixture1)),
+				msg: queue.Message{
+					Body: string(mustMarshal(runJobFixture1)),
+				},
 				token: token{},
 			},
 			want: true,
@@ -208,7 +211,9 @@ func TestRunner_ProcessMessage(t *testing.T) {
 				CheckUpdater:   &inMemChecksUpdater{},
 			},
 			args: args{
-				msg:   string(mustMarshal(runJobFixture1)),
+				msg: queue.Message{
+					Body: string(mustMarshal(runJobFixture1)),
+				},
 				token: token{},
 			},
 			want: false,
@@ -254,7 +259,9 @@ func TestRunner_ProcessMessage(t *testing.T) {
 				CheckUpdater:   &inMemChecksUpdater{},
 			},
 			args: args{
-				msg:   string(mustMarshal(runJobFixture1)),
+				msg: queue.Message{
+					Body: string(mustMarshal(runJobFixture1)),
+				},
 				token: token{},
 			},
 			want: true,
@@ -326,7 +333,9 @@ func TestRunner_ProcessMessage(t *testing.T) {
 				CheckUpdater:   &inMemChecksUpdater{},
 			},
 			args: args{
-				msg:   string(mustMarshal(runJobFixture1)),
+				msg: queue.Message{
+					Body: string(mustMarshal(runJobFixture1)),
+				},
 				token: token{},
 			},
 			want: true,
@@ -402,7 +411,9 @@ func TestRunner_ProcessMessage(t *testing.T) {
 				CheckUpdater:   &inMemChecksUpdater{},
 			},
 			args: args{
-				msg:   string(mustMarshal(runJobFixture1)),
+				msg: queue.Message{
+					Body: string(mustMarshal(runJobFixture1)),
+				},
 				token: token{},
 			},
 			want: true,
@@ -464,7 +475,9 @@ func TestRunner_ProcessMessage(t *testing.T) {
 				},
 			},
 			args: args{
-				msg:   string(mustMarshal(runJobFixture1)),
+				msg: queue.Message{
+					Body: string(mustMarshal(runJobFixture1)),
+				},
 				token: token{},
 			},
 			want: false,

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -13,11 +13,21 @@ var (
 	ErrMaxTimeNoRead = errors.New("no messages available in the queue for more than the max time")
 )
 
+// Message defines the information a queue reader passes to a processor about a
+// message.
+type Message struct {
+	// Body contains the body of the message to be processed.
+	Body string
+	// TimesRead contains the number of times this concrete message has been
+	// read so far.
+	TimesRead int
+}
+
 // MessageProcessor defines the methods needed by a queue reader implementation
 // to process the messages it reads.
 type MessageProcessor interface {
 	FreeTokens() chan interface{}
-	ProcessMessage(msg string, token interface{}) <-chan bool
+	ProcessMessage(msg Message, token interface{}) <-chan bool
 }
 
 // Reader defines the functions that all the concrete queue reader

--- a/queue/sqs/reader.go
+++ b/queue/sqs/reader.go
@@ -85,6 +85,7 @@ func NewReader(log log.Logger, cfg config.SQSReader, maxTimeNoRead *time.Duratio
 		MaxNumberOfMessages: aws.Int64(1),
 		WaitTimeSeconds:     aws.Int64(0),
 		VisibilityTimeout:   aws.Int64(int64(cfg.VisibilityTimeout)),
+		AttributeNames:      []*string{aws.String("ApproximateReceiveCount")},
 	}
 	return &Reader{
 		RWMutex:               &sync.RWMutex{},
@@ -156,6 +157,7 @@ func (r *Reader) readMessage(ctx context.Context) (*sqs.Message, error) {
 	start := time.Now()
 	for {
 		r.receiveParams.WaitTimeSeconds = &waitTime
+
 		resp, err := r.sqs.ReceiveMessageWithContext(ctx, &r.receiveParams)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {

--- a/queue/sqs/reader.go
+++ b/queue/sqs/reader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -207,7 +208,19 @@ func (r *Reader) processAndTrack(msg *sqs.Message, token interface{}) {
 			r.log.Errorf("deleting processed message", err.Error())
 		}
 	}
-	processed := r.Processor.ProcessMessage(*msg.Body, token)
+	m := queue.Message{Body: *msg.Body}
+	var (
+		n   int
+		err error
+	)
+	if rc, ok := msg.Attributes["ApproximateReceiveCount"]; ok && rc != nil {
+		n, err = strconv.Atoi(*rc)
+		if err != nil {
+			r.log.Errorf("error reading ApproximateReceiveCount msg attribute %v", err)
+		}
+	}
+	m.TimesRead = n
+	processed := r.Processor.ProcessMessage(m, token)
 	timer := time.NewTimer(time.Duration(r.processMessageQuantum) * time.Second)
 loop:
 	for {

--- a/queue/sqs/reader_test.go
+++ b/queue/sqs/reader_test.go
@@ -98,7 +98,7 @@ func (sq *InMemSQS) DeleteMessage(input *sqs.DeleteMessageInput) (*sqs.DeleteMes
 type messageProcessorMock struct {
 	tokens         chan interface{}
 	freeTokens     func() chan interface{}
-	processMessage func(msg string, token interface{}) <-chan bool
+	processMessage func(m queue.Message, token interface{}) <-chan bool
 }
 
 func (mp *messageProcessorMock) FreeTokens() chan interface{} {
@@ -108,8 +108,8 @@ func (mp *messageProcessorMock) FreeTokens() chan interface{} {
 	return mp.tokens
 }
 
-func (mp *messageProcessorMock) ProcessMessage(msg string, token interface{}) <-chan bool {
-	return mp.processMessage(msg, token)
+func (mp *messageProcessorMock) ProcessMessage(m queue.Message, token interface{}) <-chan bool {
+	return mp.processMessage(m, token)
 }
 
 func TestReader_StartReading(t *testing.T) {
@@ -165,7 +165,7 @@ func TestReader_StartReading(t *testing.T) {
 						res <- struct{}{}
 						return res
 					},
-					processMessage: func(msg string, token interface{}) <-chan bool {
+					processMessage: func(msg queue.Message, token interface{}) <-chan bool {
 						c := make(chan bool, 1)
 						go func() {
 							time.Sleep(3 * time.Second)
@@ -240,7 +240,7 @@ func TestReader_StartReading(t *testing.T) {
 						res <- struct{}{}
 						return res
 					},
-					processMessage: func(msg string, token interface{}) <-chan bool {
+					processMessage: func(q queue.Message, token interface{}) <-chan bool {
 						c := make(chan bool, 1)
 						go func() {
 							time.Sleep(3 * time.Second)
@@ -316,7 +316,7 @@ func TestReader_StartReading(t *testing.T) {
 						res <- struct{}{}
 						return res
 					},
-					processMessage: func(msg string, token interface{}) <-chan bool {
+					processMessage: func(q queue.Message, token interface{}) <-chan bool {
 						c := make(chan bool, 1)
 						go func() {
 							time.Sleep(1 * time.Second)


### PR DESCRIPTION
This PR adds a new config parameter, named:  max_message_processed_times in the "agent" config section that specifies the maximum times a message can be processed before the agent marks the corresponding check as failed and stops trying to process the message. 