### PR TITLE
Print error when message processed to many times

### DIFF
--- a/jobrunner/runner.go
+++ b/jobrunner/runner.go
@@ -198,7 +198,7 @@ func (cr *Runner) runJob(m queue.Message, t interface{}, processed chan bool) {
 			cr.finishJob(j.CheckID, processed, false, err)
 			return
 		}
-		err = fmt.Errorf("error max processed times exceeded for check: %s, error: %w", j.CheckID, err)
+		cr.Logger.Errorf("error max processed times exceeded for check: %s", j.CheckID)
 		cr.finishJob(j.CheckID, processed, true, nil)
 		return
 	}


### PR DESCRIPTION
This PR just fixes and issue that was preventing the agent to log an error when a message is deleted because it was processed to many times.