### PR TITLE
Results: no permanent errors and trim payloads

### DIFF
--- a/results/upload.go
+++ b/results/upload.go
@@ -19,6 +19,12 @@ import (
 	report "github.com/adevinta/vulcan-report"
 )
 
+const (
+	// MaxEntitySize defines the maximum number of kB's of the payloads the Results client
+	// can send to the Results service.
+	MaxEntitySize = 1024 * 7 // 7 MB's
+)
+
 // ReportData represents the payload for report upload requests.
 type ReportData struct {
 	Report        string    `json:"report"`
@@ -95,8 +101,11 @@ func (u *Uploader) UpdateCheckReport(checkID string, scanStartTime time.Time, re
 // UpdateCheckRaw stores the log of the execution of a check in results service
 // an returns a link that can be used to retreive the logs.
 func (u *Uploader) UpdateCheckRaw(checkID string, scanStartTime time.Time, raw []byte) (string, error) {
+	if len(raw) > MaxEntitySize*1024 {
+		raw = raw[0:MaxEntitySize]
+	}
 	path := path.Join("raw")
-	// We are not going to process scan id's at he agent level.
+	// We are not going to process scan id's at the agent level.
 	rawData := RawData{
 		CheckID:       checkID,
 		ScanID:        checkID,
@@ -144,8 +153,9 @@ func (u *Uploader) jsonRequest(route string, reqBody []byte) (string, error) {
 	location, exists := res.Header["Location"]
 	if !exists || len(location) <= 0 {
 		body := u.tryReadBody(res)
-		errMsg := fmt.Sprintf("invalid response, status: %s, body: %s", res.Status, body)
-		err := fmt.Errorf("%s, %w", errMsg, retryer.ErrPermanent)
+		// Even if the response does not have the proper format the error could
+		// be transient, so we don't return a permanent error here.
+		err := fmt.Errorf("invalid response, status: %s, body: %s", res.Status, body)
 		return "", err
 	}
 	if res.StatusCode == http.StatusCreated && len(location) > 0 {

--- a/results/upload.go
+++ b/results/upload.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	// MaxEntitySize defines the maximum number of kB's of the payloads the Results client
+	// MaxEntitySize defines the maximum number of bytes of the payloads the Results client
 	// can send to the Results service.
-	MaxEntitySize = 1024 * 7 // 7 MB's
+	MaxEntitySize = 1024 * 1024 * 7 // 7 MB's
 )
 
 // ReportData represents the payload for report upload requests.
@@ -101,8 +101,8 @@ func (u *Uploader) UpdateCheckReport(checkID string, scanStartTime time.Time, re
 // UpdateCheckRaw stores the log of the execution of a check in results service
 // an returns a link that can be used to retreive the logs.
 func (u *Uploader) UpdateCheckRaw(checkID string, scanStartTime time.Time, raw []byte) (string, error) {
-	if len(raw) > MaxEntitySize*1024 {
-		raw = raw[0:MaxEntitySize]
+	if len(raw) > MaxEntitySize {
+		raw = raw[:MaxEntitySize-1]
 	}
 	path := path.Join("raw")
 	// We are not going to process scan id's at the agent level.


### PR DESCRIPTION
This PR modifies the results client, so:

1. Al the status codes returned by the results service are no permanent, so it will retry. That's because we found out that in some cases the results service (or intermediate elements like ingresses) can return http status codes like 400 for transient errors.
2. The results client limits the max size of the logs to be sent to 7 MB's.  Logs that exceed that that size are truncated. 