### PR TITLE
Stricter version

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -21,9 +21,9 @@ const (
 	AgentAddressVar     = "VULCAN_AGENT_ADDRESS"
 )
 
-// ErrConExitUnexpected is returned by the docker backend when a
-// container was killed externally while running.
-var ErrConExitUnexpected = errors.New("container finished unexpectedly")
+// ErrNotZeroExitCode is returned by the docker backend when a container
+// finished with an exit code different from 0.
+var ErrNotZeroExitCode = errors.New("container finished unexpectedly")
 
 // RunResult defines the info that must be returned when a check is
 // finished.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -21,9 +21,9 @@ const (
 	AgentAddressVar     = "VULCAN_AGENT_ADDRESS"
 )
 
-// ErrNotZeroExitCode is returned by the docker backend when a container
+// ErrNonZeroExitCode is returned by the docker backend when a container
 // finished with an exit code different from 0.
-var ErrNotZeroExitCode = errors.New("container finished unexpectedly")
+var ErrNonZeroExitCode = errors.New("container finished unexpectedly")
 
 // RunResult defines the info that must be returned when a check is
 // finished.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -4,7 +4,10 @@ Copyright 2021 Adevinta
 
 package backend
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // Constants defining environment variables that a check expects.
 const (
@@ -17,6 +20,10 @@ const (
 	CheckLogLevelVar    = "VULCAN_CHECK_LOG_LVL"
 	AgentAddressVar     = "VULCAN_AGENT_ADDRESS"
 )
+
+// ErrConExitUnexpected is returned by the docker backend when a
+// container was killed externally while running.
+var ErrConExitUnexpected = errors.New("container finished unexpectedly")
 
 // RunResult defines the info that must be returned when a check is
 // finished.

--- a/backend/docker/docker.go
+++ b/backend/docker/docker.go
@@ -140,7 +140,7 @@ func (b *Docker) run(ctx context.Context, params backend.RunParams, res chan<- b
 	}
 
 	if exit != 0 && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-		err = fmt.Errorf("%w exit: %d", backend.ErrNotZeroExitCode, exit)
+		err = fmt.Errorf("%w exit: %d", backend.ErrNonZeroExitCode, exit)
 	}
 
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/backend/docker/docker.go
+++ b/backend/docker/docker.go
@@ -130,17 +130,17 @@ func (b *Docker) run(ctx context.Context, params backend.RunParams, res chan<- b
 		return
 	}
 
-	var status int64
-	status, err = b.cli.ContainerWait(ctx, contID)
-	b.log.Debugf("container with ID %s finished with status %d", contID, status)
+	var exit int64
+	exit, err = b.cli.ContainerWait(ctx, contID)
+	b.log.Debugf("container with ID %s finished with exit code %d", contID, exit)
 	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		err := fmt.Errorf("error running container for check %s: %w", params.CheckID, err)
 		res <- backend.RunResult{Error: err}
 		return
 	}
 
-	if status != 0 && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-		err = fmt.Errorf("%w status: %d", backend.ErrConExitUnexpected, status)
+	if exit != 0 && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		err = fmt.Errorf("%w exit: %d", backend.ErrNotZeroExitCode, exit)
 	}
 
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/backend/docker/docker.go
+++ b/backend/docker/docker.go
@@ -26,10 +26,6 @@ import (
 
 const abortTimeout = 5 * time.Second
 
-// ErrConExitUnexpected is returned by the docker backend when a
-// container was killed externally while running.
-var ErrConExitUnexpected = errors.New("container finished unexpectedly")
-
 // Client defines the shape of the docker client component needed by the docker
 // backend in order to be able to run checks.
 type Client interface {
@@ -144,7 +140,7 @@ func (b *Docker) run(ctx context.Context, params backend.RunParams, res chan<- b
 	}
 
 	if status != 0 && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-		err = fmt.Errorf("%w status: %d", ErrConExitUnexpected, status)
+		err = fmt.Errorf("%w status: %d", backend.ErrConExitUnexpected, status)
 	}
 
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/backend/docker/docker_test.go
+++ b/backend/docker/docker_test.go
@@ -215,8 +215,8 @@ func TestIntegrationDockerDetectUnexpectedExit(t *testing.T) {
 	}
 	got := <-gotChan
 	gotErr := got.Error
-	if !errors.Is(gotErr, backend.ErrConExitUnexpected) {
-		t.Errorf("wantError!=gotErr, %+v!=%+v", backend.ErrConExitUnexpected, gotErr)
+	if !errors.Is(gotErr, backend.ErrNotZeroExitCode) {
+		t.Errorf("wantError!=gotErr, %+v!=%+v", backend.ErrNotZeroExitCode, gotErr)
 		return
 	}
 }

--- a/backend/docker/docker_test.go
+++ b/backend/docker/docker_test.go
@@ -215,8 +215,8 @@ func TestIntegrationDockerDetectUnexpectedExit(t *testing.T) {
 	}
 	got := <-gotChan
 	gotErr := got.Error
-	if !errors.Is(gotErr, backend.ErrNotZeroExitCode) {
-		t.Errorf("wantError!=gotErr, %+v!=%+v", backend.ErrNotZeroExitCode, gotErr)
+	if !errors.Is(gotErr, backend.ErrNonZeroExitCode) {
+		t.Errorf("wantError!=gotErr, %+v!=%+v", backend.ErrNonZeroExitCode, gotErr)
 		return
 	}
 }

--- a/backend/docker/docker_test.go
+++ b/backend/docker/docker_test.go
@@ -215,8 +215,8 @@ func TestIntegrationDockerDetectUnexpectedExit(t *testing.T) {
 	}
 	got := <-gotChan
 	gotErr := got.Error
-	if !errors.Is(gotErr, ErrConExitUnexpected) {
-		t.Errorf("wantError!=gotErr, %+v!=%+v", ErrConExitUnexpected, gotErr)
+	if !errors.Is(gotErr, backend.ErrConExitUnexpected) {
+		t.Errorf("wantError!=gotErr, %+v!=%+v", backend.ErrConExitUnexpected, gotErr)
 		return
 	}
 }

--- a/jobrunner/runner.go
+++ b/jobrunner/runner.go
@@ -310,7 +310,7 @@ func (cr *Runner) runJob(m queue.Message, t interface{}, processed chan bool) {
 	if execErr != nil &&
 		!errors.Is(execErr, context.DeadlineExceeded) &&
 		!errors.Is(execErr, context.Canceled) &&
-		!errors.Is(execErr, backend.ErrConExitUnexpected) {
+		!errors.Is(execErr, backend.ErrNotZeroExitCode) {
 		cr.finishJob(j.CheckID, processed, false, execErr)
 		return
 	}
@@ -325,7 +325,7 @@ func (cr *Runner) runJob(m queue.Message, t interface{}, processed chan bool) {
 	if errors.Is(execErr, context.Canceled) {
 		status = stateupdater.StatusAborted
 	}
-	if errors.Is(execErr, backend.ErrConExitUnexpected) {
+	if errors.Is(execErr, backend.ErrNotZeroExitCode) {
 		status = stateupdater.StatusFailed
 	}
 	// Ensure the check sent a status update with a terminal status.

--- a/jobrunner/runner.go
+++ b/jobrunner/runner.go
@@ -309,8 +309,8 @@ func (cr *Runner) runJob(m queue.Message, t interface{}, processed chan bool) {
 	execErr := res.Error
 	if execErr != nil &&
 		!errors.Is(execErr, context.DeadlineExceeded) &&
-		!errors.Is(execErr, context.Canceled) { // &&
-		// !errors.Is(execErr, backend.ErrConExitUnexpected) {
+		!errors.Is(execErr, context.Canceled) &&
+		!errors.Is(execErr, backend.ErrConExitUnexpected) {
 		cr.finishJob(j.CheckID, processed, false, execErr)
 		return
 	}

--- a/jobrunner/runner.go
+++ b/jobrunner/runner.go
@@ -301,8 +301,8 @@ func (cr *Runner) runJob(m queue.Message, t interface{}, processed chan bool) {
 	execErr := res.Error
 	if execErr != nil &&
 		!errors.Is(execErr, context.DeadlineExceeded) &&
-		!errors.Is(execErr, context.Canceled) &&
-		!errors.Is(execErr, backend.ErrConExitUnexpected) {
+		!errors.Is(execErr, context.Canceled) { // &&
+		// !errors.Is(execErr, backend.ErrConExitUnexpected) {
 		cr.finishJob(j.CheckID, processed, false, execErr)
 		return
 	}

--- a/jobrunner/runner.go
+++ b/jobrunner/runner.go
@@ -187,7 +187,7 @@ func (cr *Runner) runJob(m queue.Message, t interface{}, processed chan bool) {
 		cr.finishJob("", processed, true, err)
 		return
 	}
-
+	cr.Logger.Infof("running check %s", j.CheckID)
 	// Check if the message has been processed more than the maximum defined
 	// times.
 	if m.TimesRead > cr.maxMessageProcessedTimes {
@@ -336,6 +336,9 @@ func (cr *Runner) runJob(m queue.Message, t interface{}, processed chan bool) {
 }
 
 func (cr *Runner) finishJob(checkID string, processed chan<- bool, delete bool, err error) {
+	if err == nil && checkID != "" {
+		cr.Logger.Infof("finished running check %s with no error, mark to be deleted: %+v", checkID, delete)
+	}
 	if err != nil && checkID != "" {
 		cr.Logger.Errorf("error %+v running check_id %s", err, checkID)
 	}

--- a/jobrunner/runner_test.go
+++ b/jobrunner/runner_test.go
@@ -736,7 +736,7 @@ func TestRunner_ProcessMessage(t *testing.T) {
 				return fmt.Sprintf("%s%s", rawsDiff, updateDiff)
 			},
 		},
-		/*{
+		{
 			name: "UpdatesStateWhenCheckStatusUnexpected",
 			fields: fields{
 				Backend: &mockBackend{
@@ -801,14 +801,13 @@ func TestRunner_ProcessMessage(t *testing.T) {
 					{
 						ID:     runJobFixture1.CheckID,
 						Status: &state,
-						// Raw: &rawLink,
 					},
 				}
 				rawsDiff := cmp.Diff(wantRaws, gotRaws)
 				updateDiff := cmp.Diff(wantUpdates, gotUpdates)
 				return fmt.Sprintf("%s%s", rawsDiff, updateDiff)
 			},
-		},*/
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/jobrunner/runner_test.go
+++ b/jobrunner/runner_test.go
@@ -22,15 +22,6 @@ import (
 )
 
 var (
-	terminalStatuses = map[string]struct{}{
-		stateupdater.StatusFailed:       {},
-		stateupdater.StatusFinished:     {},
-		stateupdater.StatusInconclusive: {},
-		stateupdater.StatusKilled:       {},
-		stateupdater.StatusMalformed:    {},
-		stateupdater.StatusTimeout:      {},
-	}
-
 	errUnexpectedTest = errors.New("unexpected")
 
 	runJobFixture1 = Job{
@@ -91,7 +82,7 @@ func (im *inMemChecksUpdater) CheckStatusTerminal(ID string) bool {
 		if u.Status != nil {
 			status = *u.Status
 		}
-		if _, ok := terminalStatuses[status]; ok {
+		if _, ok := stateupdater.TerminalStatuses[status]; ok {
 			return true
 		}
 	}
@@ -749,7 +740,7 @@ func TestRunner_ProcessMessage(t *testing.T) {
 							}
 							results := backend.RunResult{
 								Output: output,
-								Error:  backend.ErrNotZeroExitCode,
+								Error:  backend.ErrNonZeroExitCode,
 							}
 							res <- results
 						}()

--- a/jobrunner/runner_test.go
+++ b/jobrunner/runner_test.go
@@ -749,7 +749,7 @@ func TestRunner_ProcessMessage(t *testing.T) {
 							}
 							results := backend.RunResult{
 								Output: output,
-								Error:  backend.ErrConExitUnexpected,
+								Error:  backend.ErrNotZeroExitCode,
 							}
 							res <- results
 						}()

--- a/jobrunner/runner_test.go
+++ b/jobrunner/runner_test.go
@@ -614,7 +614,7 @@ func TestRunner_ProcessMessage(t *testing.T) {
 				return fmt.Sprintf("%s%s", rawsDiff, updateDiff)
 			},
 		},
-		{
+		/*{
 			name: "UpdatesStateWhenCheckStatusUnexpected",
 			fields: fields{
 				Backend: &mockBackend{
@@ -686,7 +686,7 @@ func TestRunner_ProcessMessage(t *testing.T) {
 				updateDiff := cmp.Diff(wantUpdates, gotUpdates)
 				return fmt.Sprintf("%s%s", rawsDiff, updateDiff)
 			},
-		},
+		},*/
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/queue/sqs/reader.go
+++ b/queue/sqs/reader.go
@@ -203,22 +203,25 @@ func (r *Reader) processAndTrack(msg *sqs.Message, token interface{}) {
 		atomic.AddUint32(&r.nProcessingMessages, ^uint32(0))
 		r.wg.Done()
 	}()
-	if msg.Body == nil {
-		r.log.Errorf("unexpected empty body message from sqs")
+	err := validateSQSMessage(msg)
+	if err != nil {
+		r.log.Errorf("error %+v", err)
+		if msg.ReceiptHandle == nil {
+			r.log.Errorf("cannot delete invalid message, receipt handle is empty")
+			return
+		}
 		// Invalid message delete from queue without processing.
 		_, err := r.sqs.DeleteMessage(&sqs.DeleteMessageInput{
 			ReceiptHandle: msg.ReceiptHandle,
 			QueueUrl:      r.receiveParams.QueueUrl,
 		})
 		if err != nil {
-			r.log.Errorf("deleting processed message", err.Error())
+			r.log.Errorf("deleting invalid message", err.Error())
 		}
+		return
 	}
 	m := queue.Message{Body: *msg.Body}
-	var (
-		n   int
-		err error
-	)
+	var n int
 	if rc, ok := msg.Attributes["ApproximateReceiveCount"]; ok && rc != nil {
 		n, err = strconv.Atoi(*rc)
 		if err != nil {
@@ -271,4 +274,20 @@ func (r *Reader) LastMessageReceived() *time.Time {
 	r.RLock()
 	defer r.RUnlock()
 	return r.lastMessageReceived
+}
+
+func validateSQSMessage(msg *sqs.Message) error {
+	if msg == nil {
+		return errors.New("unexpected empty message")
+	}
+	if msg.Body == nil {
+		return errors.New("unexpected empty body message")
+	}
+	if msg.MessageId == nil {
+		return errors.New("unexpected empty message id")
+	}
+	if msg.ReceiptHandle == nil {
+		return errors.New("unexpected empty receipt handle")
+	}
+	return nil
 }

--- a/queue/sqs/reader.go
+++ b/queue/sqs/reader.go
@@ -203,6 +203,10 @@ func (r *Reader) processAndTrack(msg *sqs.Message, token interface{}) {
 		atomic.AddUint32(&r.nProcessingMessages, ^uint32(0))
 		r.wg.Done()
 	}()
+	if msg == nil {
+		r.log.Errorf("cannot process nil message")
+		return
+	}
 	err := validateSQSMessage(msg)
 	if err != nil {
 		r.log.Errorf("error %+v", err)

--- a/queue/sqs/reader.go
+++ b/queue/sqs/reader.go
@@ -250,7 +250,7 @@ loop:
 				r.log.Errorf("unexpected error processing message with id: %s, message not deleted", *msg.MessageId)
 				break loop
 			}
-
+			r.log.Infof("deleting message with id %s", *msg.MessageId)
 			input := &sqs.DeleteMessageInput{
 				QueueUrl:      r.receiveParams.QueueUrl,
 				ReceiptHandle: msg.ReceiptHandle,

--- a/stateupdater/updater.go
+++ b/stateupdater/updater.go
@@ -24,7 +24,9 @@ const (
 	StatusInconclusive = "INCONCLUSIVE"
 )
 
-var terminalStatuses = map[string]struct{}{
+// TerminalStatuses contains all the possible statuses of a check that are
+// terminal.
+var TerminalStatuses = map[string]struct{}{
 	StatusFailed:       {},
 	StatusFinished:     {},
 	StatusInconclusive: {},
@@ -76,7 +78,7 @@ func (u *Updater) UpdateState(s CheckState) error {
 	if s.Status != nil {
 		status = *s.Status
 	}
-	if _, ok := terminalStatuses[status]; ok {
+	if _, ok := TerminalStatuses[status]; ok {
 		u.terminalChecks.Store(s.ID, struct{}{})
 	}
 	return nil


### PR DESCRIPTION
This PR modifies the behaviour of the agent to make it more strict in ensuring that, when a check has finished running, there will always be a message in the status queue with a terminal status for the check. Concretely:
1. The agent will now mark a check a FAILED whenever it finishes with a return code different from 0. Before the agent was not marking the check as failed and wasn't deleting the message for executing the check from the queue, so the agent retried the check execution the configured amount of times before marking it as FAILED. I decided to change this behaviour after observing that majority of the checks that finish with a status != 0 it because and persistent error that is not fixed with retries. 
2. After a docker container is finished the agent queries the state updater component in order know if the check sent any message with a terminal status, if not, it will send a message for the check with status failed. Initially we didn't want to do this because it implies we will need to resolve additional problems when we implement a backend for k8s, but seeing that some of the checks we want to run in the future have many chances to fail in this way I think it is better to implement this in order to avoid having leaked checks and tackle the additional problems when we implement the k8s backend.  