### PR TITLE
Update vulcan-report and add trace for missing fields

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -94,6 +94,30 @@ func (a *API) CheckUpdate(c CheckState) error {
 			return err
 		}
 		rlink = &link
+
+		// Log every single vulnerability reported by the check that is missing
+		// the new vulcan-report.Vulnerability.{Category,AffectedResource} field.
+		mC := make(map[string]bool)
+		mAR := make(map[string]bool)
+		for _, v := range c.Report.Vulnerabilities {
+			if mC[v.Summary] && mAR[v.Summary] {
+				continue
+			}
+			if !mC[v.Summary] {
+				mC[v.Summary] = true
+
+				if v.Category == "" {
+					a.log.Infof("report from [%s] does not contain a category for [%s]", c.Report.ChecktypeName, v.Summary)
+				}
+			}
+			if !mAR[v.Summary] {
+				mAR[v.Summary] = true
+
+				if v.AffectedResource == "" {
+					a.log.Infof("report from [%s] does not contain an affected resource for [%s]", c.Report.ChecktypeName, v.Summary)
+				}
+			}
+		}
 	}
 	ustate := stateupdater.CheckState{
 		ID:     c.ID,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/adevinta/dockerutils v0.0.0-20190826104125-915f26bde8e5
 	github.com/adevinta/vulcan-metrics-client v0.0.0-20200617105830-6078a0e12ebd
-	github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff
+	github.com/adevinta/vulcan-report v0.0.0-20210528090423-5280af1d1f0b
 	github.com/aws/aws-sdk-go v1.30.11
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
@@ -21,7 +21,5 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lestrrat-go/backoff v1.0.0
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/stretchr/testify v1.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,12 @@ github.com/adevinta/dockerutils v0.0.0-20190826104125-915f26bde8e5 h1:dAEZKbV4ab
 github.com/adevinta/dockerutils v0.0.0-20190826104125-915f26bde8e5/go.mod h1:Tf9DLLpE2bthMKu7ndZYc0jWnxyCY+KPvJGqn9RnqMU=
 github.com/adevinta/vulcan-metrics-client v0.0.0-20200617105830-6078a0e12ebd h1:gI+Ni3OjDLbA/ysKq+bdhwQHkTDCsDVWGM1I13gxaME=
 github.com/adevinta/vulcan-metrics-client v0.0.0-20200617105830-6078a0e12ebd/go.mod h1:M+oEghaodOSKYMScXw7Vpz9DypFo6PbgIEJrAexyWBo=
-github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff h1:ZazuZSOfV8oo70SWdjLQi+In4GSmJCA2rwsliyz9KNs=
-github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff/go.mod h1:GtAon6TymHFTOPwRdR7SHun/TSM1kyPMQYXxGLTR8eQ=
+github.com/adevinta/vulcan-report v0.0.0-20210521100022-c030b00612f6 h1:0FjQhy8ZVs8F5RHyX5Y0kIXqT+UVxLDQlzVTOSf9i2I=
+github.com/adevinta/vulcan-report v0.0.0-20210521100022-c030b00612f6/go.mod h1:mj4gaLILjExwR6TV0zCyoSqNFaPBaGI9ngZwiOdPtA0=
+github.com/adevinta/vulcan-report v0.0.0-20210526093231-f7db675be032 h1:6L+B4NzTY059f8CFRexcvezbWGGx5sc42JqdXZJXjZU=
+github.com/adevinta/vulcan-report v0.0.0-20210526093231-f7db675be032/go.mod h1:mj4gaLILjExwR6TV0zCyoSqNFaPBaGI9ngZwiOdPtA0=
+github.com/adevinta/vulcan-report v0.0.0-20210528090423-5280af1d1f0b h1:MhWBa78rDn8w2mp7v0gl1CGkYCAQpd+o1HAe2fuqnKg=
+github.com/adevinta/vulcan-report v0.0.0-20210528090423-5280af1d1f0b/go.mod h1:mj4gaLILjExwR6TV0zCyoSqNFaPBaGI9ngZwiOdPtA0=
 github.com/aws/aws-sdk-go v1.30.11 h1:bJoa1QGyyAV4COx1SXpf+LElFVVnOreG6KM0jIxwZq0=
 github.com/aws/aws-sdk-go v1.30.11/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
@@ -53,8 +57,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,6 @@ github.com/adevinta/dockerutils v0.0.0-20190826104125-915f26bde8e5 h1:dAEZKbV4ab
 github.com/adevinta/dockerutils v0.0.0-20190826104125-915f26bde8e5/go.mod h1:Tf9DLLpE2bthMKu7ndZYc0jWnxyCY+KPvJGqn9RnqMU=
 github.com/adevinta/vulcan-metrics-client v0.0.0-20200617105830-6078a0e12ebd h1:gI+Ni3OjDLbA/ysKq+bdhwQHkTDCsDVWGM1I13gxaME=
 github.com/adevinta/vulcan-metrics-client v0.0.0-20200617105830-6078a0e12ebd/go.mod h1:M+oEghaodOSKYMScXw7Vpz9DypFo6PbgIEJrAexyWBo=
-github.com/adevinta/vulcan-report v0.0.0-20210521100022-c030b00612f6 h1:0FjQhy8ZVs8F5RHyX5Y0kIXqT+UVxLDQlzVTOSf9i2I=
-github.com/adevinta/vulcan-report v0.0.0-20210521100022-c030b00612f6/go.mod h1:mj4gaLILjExwR6TV0zCyoSqNFaPBaGI9ngZwiOdPtA0=
-github.com/adevinta/vulcan-report v0.0.0-20210526093231-f7db675be032 h1:6L+B4NzTY059f8CFRexcvezbWGGx5sc42JqdXZJXjZU=
-github.com/adevinta/vulcan-report v0.0.0-20210526093231-f7db675be032/go.mod h1:mj4gaLILjExwR6TV0zCyoSqNFaPBaGI9ngZwiOdPtA0=
 github.com/adevinta/vulcan-report v0.0.0-20210528090423-5280af1d1f0b h1:MhWBa78rDn8w2mp7v0gl1CGkYCAQpd+o1HAe2fuqnKg=
 github.com/adevinta/vulcan-report v0.0.0-20210528090423-5280af1d1f0b/go.mod h1:mj4gaLILjExwR6TV0zCyoSqNFaPBaGI9ngZwiOdPtA0=
 github.com/aws/aws-sdk-go v1.30.11 h1:bJoa1QGyyAV4COx1SXpf+LElFVVnOreG6KM0jIxwZq0=


### PR DESCRIPTION
- Update vulcan-report dependency.
- Add a trace to identify checks with missing new attributes.