### PR TITLE
Improve tests

### DIFF
--- a/backend/docker/docker_test.go
+++ b/backend/docker/docker_test.go
@@ -351,7 +351,10 @@ func TestIntegrationDockerFindImage(t *testing.T) {
 
 		// Check if the valid references are valid.
 		for _, v := range c.valids {
-			if exists, _ := b.imageExists(context.Background(), v); !exists {
+			exists, err := b.imageExists(context.Background(), v)
+			if err != nil {
+				t.Errorf("image:%s %s error:%+v", c.image, v, err)
+			} else if !exists {
 				t.Errorf("image:%s %s should exists", c.image, v)
 			}
 		}
@@ -367,8 +370,10 @@ func TestIntegrationDockerFindImage(t *testing.T) {
 
 			// Skip if it is valid.
 			if !valid {
-				// This reference should'n exists
-				if exists, _ := b.imageExists(context.Background(), r); exists {
+				exists, err := b.imageExists(context.Background(), r)
+				if err != nil {
+					t.Errorf("image:%s %s error:%+v", c.image, r, err)
+				} else if exists {
 					t.Errorf("image:%s %s should not exists", c.image, r)
 				}
 			}


### PR DESCRIPTION
Upgrading to docker v23 makes the tests fails because of this
`client version 1.42 is too new. Maximum supported API version is 1.41`

With this pr the test will reveal this message.