### PR TITLE
Fix the issue with missing raws.

### DIFF
--- a/jobrunner/runner_test.go
+++ b/jobrunner/runner_test.go
@@ -112,7 +112,7 @@ func (im *inMemChecksUpdater) UpdateCheckStatusTerminal(s stateupdater.CheckStat
 	}
 
 	// We update the existing CheckState.
-	cs.Update(s)
+	cs.Merge(s)
 
 	im.terminalStatus[cs.ID] = cs
 }

--- a/jobrunner/runner_test.go
+++ b/jobrunner/runner_test.go
@@ -105,30 +105,16 @@ func (im *inMemChecksUpdater) UpdateCheckStatusTerminal(s stateupdater.CheckStat
 	if im.terminalStatus == nil {
 		im.terminalStatus = make(map[string]stateupdater.CheckState)
 	}
-	checkState, ok := im.terminalStatus[s.ID]
+	cs, ok := im.terminalStatus[s.ID]
 	if !ok {
 		im.terminalStatus[s.ID] = s
 		return
 	}
 
-	// We update the existing CheckState
-	if s.Status != nil {
-		checkState.Status = s.Status
-	}
-	if s.Raw != nil {
-		checkState.Raw = s.Raw
-	}
-	if s.AgentID != nil {
-		checkState.AgentID = s.AgentID
-	}
-	if s.Progress != nil {
-		checkState.Progress = s.Progress
-	}
-	if s.Report != nil {
-		checkState.Report = s.Report
-	}
+	// We update the existing CheckState.
+	cs.Update(s)
 
-	im.terminalStatus[checkState.ID] = checkState
+	im.terminalStatus[cs.ID] = cs
 }
 
 func (im *inMemChecksUpdater) FlushCheckStatus(ID string) error {

--- a/stateupdater/updater.go
+++ b/stateupdater/updater.go
@@ -46,9 +46,9 @@ type CheckState struct {
 	Progress *float32 `json:"progress,omitempty"`
 }
 
-// Update updates the fields of a check state with the values from the check state
-// passed as argument.
-func (cs *CheckState) Update(s CheckState) {
+// Merge overrides the fields of the receiver with the value of the non nil
+// fields of the provided CheckState.
+func (cs *CheckState) Merge(s CheckState) {
 	if s.Status != nil {
 		cs.Status = s.Status
 	}
@@ -153,7 +153,7 @@ func (u *Updater) UpdateCheckStatusTerminal(s CheckState) {
 	cs := checkState.(CheckState)
 
 	// We update the existing CheckState.
-	cs.Update(s)
+	cs.Merge(s)
 
 	u.terminalChecks.Store(s.ID, cs)
 }

--- a/stateupdater/updater.go
+++ b/stateupdater/updater.go
@@ -46,6 +46,26 @@ type CheckState struct {
 	Progress *float32 `json:"progress,omitempty"`
 }
 
+// Update updates the fields of a check state with the values from the check state
+// passed as argument.
+func (cs *CheckState) Update(s CheckState) {
+	if s.Status != nil {
+		cs.Status = s.Status
+	}
+	if s.Raw != nil {
+		cs.Raw = s.Raw
+	}
+	if s.AgentID != nil {
+		cs.AgentID = s.AgentID
+	}
+	if s.Progress != nil {
+		cs.Progress = s.Progress
+	}
+	if s.Report != nil {
+		cs.Report = s.Report
+	}
+}
+
 // QueueWriter defines the queue services used by and
 // updater to send the status updates.
 type QueueWriter interface {
@@ -132,22 +152,8 @@ func (u *Updater) UpdateCheckStatusTerminal(s CheckState) {
 	}
 	cs := checkState.(CheckState)
 
-	// We update the existing CheckState
-	if s.Status != nil {
-		cs.Status = s.Status
-	}
-	if cs.Raw != nil {
-		cs.Raw = s.Raw
-	}
-	if cs.AgentID != nil {
-		cs.AgentID = s.AgentID
-	}
-	if cs.Progress != nil {
-		cs.Progress = s.Progress
-	}
-	if cs.Report != nil {
-		cs.Report = s.Report
-	}
+	// We update the existing CheckState.
+	cs.Update(s)
 
 	u.terminalChecks.Store(s.ID, cs)
 }


### PR DESCRIPTION
**Problem**
The raw field had stopped being sent to the queue which is then processed by the scan engine.

**Analysis**
The issue was introduced at https://github.com/adevinta/vulcan-agent/pull/120. We didn't detect it because several methods are slightly different for testing purposes and for production and according to the test the raw field was being sent to the queue. We failed on checking visually that everything was ok.

**Solution**
Extract the logic that updates the fields of a check status and use it in production code and tests.
