### PR TITLE
queue: add channels based queue implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 services:
   - docker
 go:
-  - 1.19.x
+  - 1.20.x
 env:
   global:
     - CGO_ENABLED=1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/adevinta/vulcan-agent
 
-go 1.19
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.2.1

--- a/queue/chanqueue/chanqueue.go
+++ b/queue/chanqueue/chanqueue.go
@@ -1,0 +1,167 @@
+// Package chanqueue provides a local queue based on channels.
+package chanqueue
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/adevinta/vulcan-agent/queue"
+)
+
+// ChanQueue represents a queue.
+type ChanQueue struct {
+	// MaxTimeNoRead is the maximum idle time before stop
+	// processing messages.
+	MaxTimeNoRead time.Duration
+
+	c    chan queue.Message
+	proc queue.MessageProcessor
+
+	// mu protects the fields below.
+	mu         sync.RWMutex
+	lastReadAt *time.Time
+}
+
+// New returns a [ChanQueue]. Messages are processed with proc. If
+// proc is nil, a processor must be set with
+// [ChanQueue.SetMessageProcessor] before calling
+// [ChanQueue.StartReading]. Otherwise, [ChanQueue.StartReading]
+// returns an error and stops reading.
+func New(proc queue.MessageProcessor) *ChanQueue {
+	return &ChanQueue{
+		c:             make(chan queue.Message),
+		proc:          proc,
+		mu:            sync.RWMutex{},
+		MaxTimeNoRead: 10 * time.Second,
+	}
+}
+
+// StartReading starts reading messages from the queue. It reads
+// messages only when there are free tokens in the message processor.
+// It will stop reading from the queue when the provided context is
+// canceled. The caller can use the returned channel to track when the
+// reader stops reading from the queue and all the messages have been
+// processed.
+func (q *ChanQueue) StartReading(ctx context.Context) <-chan error {
+	errs := make(chan error)
+	go func() {
+		q.read(ctx, errs)
+		close(errs)
+	}()
+	return errs
+}
+
+// read reads messages from the queue and processes them with the
+// provided message processor. If no message processor has been set,
+// it sends an error to the channel and returns without reading any
+// message.
+func (q *ChanQueue) read(ctx context.Context, errs chan<- error) {
+	if q.proc == nil {
+		errs <- errors.New("message processor is missing")
+		return
+	}
+
+	var err error
+
+	wg := sync.WaitGroup{}
+
+	procCtx, procCancel := context.WithCancelCause(ctx)
+	defer procCancel(nil)
+
+loop:
+	for {
+		select {
+		case <-procCtx.Done():
+			err = context.Cause(procCtx)
+			break loop
+		case token := <-q.proc.FreeTokens():
+			wg.Add(1)
+			go func() {
+				if err := q.process(procCtx, token); err != nil {
+					procCancel(err)
+				}
+				wg.Done()
+			}()
+		}
+	}
+
+	wg.Wait()
+
+	errs <- err
+}
+
+// process waits for a message and processes it using the provided
+// [queue.MessageProcessor]. If it is not able to get a message in the
+// time specified by [ChanQueue.MaxTimeNoRead] it returns a
+// [queue.ErrMaxTimeNoRead] error.
+func (q *ChanQueue) process(ctx context.Context, token any) (err error) {
+	select {
+	case msg := <-q.c:
+		q.setLastReadAt(time.Now())
+
+		msg.TimesRead++
+
+		delete := <-q.proc.ProcessMessage(msg, token)
+		if !delete {
+			q.writeMessage(msg)
+		}
+	case <-ctx.Done():
+		err = context.Cause(ctx)
+		q.returnToken(token)
+	case <-time.After(q.MaxTimeNoRead):
+		err = queue.ErrMaxTimeNoRead
+		q.returnToken(token)
+	}
+	return
+}
+
+// returnToken returns a token. It panics if the free tokens channel
+// blocks.
+func (q *ChanQueue) returnToken(token any) {
+	select {
+	case q.proc.FreeTokens() <- token:
+	default:
+		panic("could not return token")
+	}
+}
+
+// setLastReadAt sets the time that is returned by
+// [ChanQueue.LastMessageReceived].
+func (q *ChanQueue) setLastReadAt(t time.Time) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.lastReadAt = &t
+}
+
+// LastMessageReceived returns the time when the last message was
+// read. If no messages have been read it returns nil.
+func (q *ChanQueue) LastMessageReceived() *time.Time {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	return q.lastReadAt
+}
+
+// SetMessageProcessor sets the queue's message processor. It must be
+// set before calling [ChanQueue.StartReading].
+func (q *ChanQueue) SetMessageProcessor(proc queue.MessageProcessor) {
+	q.proc = proc
+}
+
+// Write writes a message with the specified body into the queue.
+func (q *ChanQueue) Write(body string) error {
+	go func() {
+		q.c <- queue.Message{Body: body}
+	}()
+	return nil
+}
+
+// writeMessage writes the specified message into the queue.
+func (q *ChanQueue) writeMessage(msg queue.Message) {
+	go func() {
+		q.c <- msg
+	}()
+}

--- a/queue/chanqueue/chanqueue.go
+++ b/queue/chanqueue/chanqueue.go
@@ -94,7 +94,7 @@ loop:
 
 // process waits for a message and processes it using the provided
 // [queue.MessageProcessor]. If it is not able to get a message in the
-// time specified by [ChanQueue.MaxTimeNoRead] it returns a
+// time specified by ChanQueue.MaxTimeNoRead it returns a
 // [queue.ErrMaxTimeNoRead] error.
 func (q *ChanQueue) process(ctx context.Context, token any) (err error) {
 	select {

--- a/queue/chanqueue/chanqueue.go
+++ b/queue/chanqueue/chanqueue.go
@@ -1,3 +1,7 @@
+/*
+Copyright 2023 Adevinta
+*/
+
 // Package chanqueue provides a local queue based on channels.
 package chanqueue
 

--- a/queue/chanqueue/chanqueue_test.go
+++ b/queue/chanqueue/chanqueue_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright 2023 Adevinta
+*/
+
 package chanqueue
 
 import (

--- a/queue/chanqueue/chanqueue_test.go
+++ b/queue/chanqueue/chanqueue_test.go
@@ -1,0 +1,203 @@
+package chanqueue
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/adevinta/vulcan-agent/queue"
+)
+
+func TestChanQueue(t *testing.T) {
+	msgs := []queue.Message{
+		{
+			Body:      "foo",
+			TimesRead: 1,
+		},
+		{
+			Body:      "bar",
+			TimesRead: 1,
+		},
+		{
+			Body:      "foobar",
+			TimesRead: 1,
+		},
+	}
+
+	rec := newMessageRecorder()
+	q := New(rec)
+	q.MaxTimeNoRead = 100 * time.Millisecond
+
+	for _, msg := range msgs {
+		q.Write(msg.Body)
+	}
+
+	err := <-q.StartReading(context.Background())
+
+	if err != queue.ErrMaxTimeNoRead {
+		t.Errorf("unexpected error: want: queue.ErrMaxTimeNoRead, got: %v", err)
+	}
+
+	if diff := cmp.Diff(msgs, rec.Messages(), cmpopts.SortSlices(messageLess)); diff != "" {
+		t.Errorf("messages mismatch (-want +got):\n%v", diff)
+	}
+}
+
+func TestChanQueue_multiple_reads(t *testing.T) {
+	msgs := []queue.Message{
+		{
+			Body:      "foo",
+			TimesRead: 1,
+		},
+		{
+			Body:      "bar",
+			TimesRead: 1,
+		},
+		{
+			Body:      "foobar",
+			TimesRead: 1,
+		},
+	}
+	const firstBatch = 1
+
+	rec := newMessageRecorder()
+	q := New(rec)
+	q.MaxTimeNoRead = 100 * time.Millisecond
+
+	// First batch.
+	for _, msg := range msgs[:firstBatch] {
+		q.Write(msg.Body)
+	}
+
+	err := <-q.StartReading(context.Background())
+	if err != queue.ErrMaxTimeNoRead {
+		t.Errorf("unexpected error: want: queue.ErrMaxTimeNoRead, got: %v", err)
+	}
+
+	if diff := cmp.Diff(msgs[:firstBatch], rec.Messages(), cmpopts.SortSlices(messageLess)); diff != "" {
+		t.Errorf("messages mismatch (-want +got):\n%v", diff)
+	}
+
+	// Second batch.
+	for _, msg := range msgs[firstBatch:] {
+		q.Write(msg.Body)
+	}
+
+	err = <-q.StartReading(context.Background())
+	if err != queue.ErrMaxTimeNoRead {
+		t.Errorf("unexpected error: want: queue.ErrMaxTimeNoRead, got: %v", err)
+	}
+
+	if diff := cmp.Diff(msgs, rec.Messages(), cmpopts.SortSlices(messageLess)); diff != "" {
+		t.Errorf("messages mismatch (-want +got):\n%v", diff)
+	}
+}
+
+func TestChanQueue_context(t *testing.T) {
+	rec := newMessageRecorder()
+	q := New(rec)
+	q.MaxTimeNoRead = 5 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := <-q.StartReading(ctx)
+
+	if err != context.DeadlineExceeded {
+		t.Errorf("unexpected error: want: context.DeadlineExceeded, got: %v", err)
+	}
+
+	if got := rec.Messages(); got != nil {
+		t.Errorf("unexpected msgs: %#v", got)
+	}
+}
+
+func TestChanQueue_retry(t *testing.T) {
+	msg := queue.Message{
+		Body:      "foo",
+		TimesRead: 5,
+	}
+
+	rec := newMessageRecorder()
+	rec.Fails = 4
+
+	q := New(rec)
+	q.MaxTimeNoRead = 100 * time.Millisecond
+
+	q.Write(msg.Body)
+
+	err := <-q.StartReading(context.Background())
+
+	if err != queue.ErrMaxTimeNoRead {
+		t.Errorf("unexpected error: want: queue.ErrMaxTimeNoRead, got: %v", err)
+	}
+
+	if diff := cmp.Diff([]queue.Message{msg}, rec.Messages(), cmpopts.SortSlices(messageLess)); diff != "" {
+		t.Errorf("messages mismatch (-want +got):\n%v", diff)
+	}
+}
+
+type messageRecorder struct {
+	tokens chan any
+	mu     sync.RWMutex
+	msgs   []queue.Message
+	Fails  int
+}
+
+func newMessageRecorder() *messageRecorder {
+	tokens := make(chan any, 1)
+	tokens <- struct{}{}
+	return &messageRecorder{
+		tokens: tokens,
+	}
+}
+
+func (rec *messageRecorder) FreeTokens() chan any {
+	return rec.tokens
+}
+
+func (rec *messageRecorder) ProcessMessage(msg queue.Message, token any) <-chan bool {
+	c := make(chan bool)
+	go func() {
+		ok := rec.success()
+		if ok {
+			rec.recordMessage(msg)
+		}
+		rec.tokens <- token
+		c <- ok
+	}()
+	return c
+}
+
+func (rec *messageRecorder) success() bool {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	if rec.Fails == 0 {
+		return true
+	}
+	rec.Fails--
+	return false
+}
+
+func (rec *messageRecorder) recordMessage(msg queue.Message) {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	rec.msgs = append(rec.msgs, msg)
+}
+
+func (rec *messageRecorder) Messages() []queue.Message {
+	rec.mu.RLock()
+	defer rec.mu.RUnlock()
+
+	return rec.msgs
+}
+
+func messageLess(a, b queue.Message) bool {
+	return a.Body < b.Body
+}

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -25,15 +25,31 @@ type Message struct {
 	TimesRead int
 }
 
-// MessageProcessor defines the methods needed by a queue reader implementation
-// to process the messages it reads.
+// MessageProcessor defines the methods needed by a queue reader
+// implementation to process the messages it reads.
+//
+// FreeTokens returns a channel that can be used to get a token to
+// call ProcessMessage.
+//
+// ProcessMessage processes the message given a token that must be
+// obtained from FreeTokens. ProcessMessage is in charge of returning
+// the token once the message has been processed. When the message has
+// been processed the returned channel will indicate if the message
+// must be deleted from the queue or not.
 type MessageProcessor interface {
-	FreeTokens() chan interface{}
-	ProcessMessage(msg Message, token interface{}) <-chan bool
+	FreeTokens() chan any
+	ProcessMessage(msg Message, token any) <-chan bool
 }
 
-// Reader defines the functions that all the concrete queue reader
-// implementations must fullfil.
+// Reader defines the methods that all the queue reader
+// implementations must fulfill.
+//
+// StartReading starts reading messages from the queue. The caller can
+// use the returned channel to track when the reader stops reading
+// from the queue and all the messages have been processed.
+//
+// LastMessageReceived returns the time when the last message was
+// read. If no messages have been read it returns nil.
 type Reader interface {
 	StartReading(ctx context.Context) <-chan error
 	LastMessageReceived() *time.Time


### PR DESCRIPTION
Add a local queue implementation based on channels.

Note that this PR also upgrades Go to version v1.20, so we can use [context.WithCancelCause](https://pkg.go.dev/context#WithCancelCause).