### PR TITLE
agent: allow to provide a listener to serve the agent API

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/BurntSushi/toml"
@@ -73,9 +74,18 @@ type S3Writer struct {
 
 // APIConfig defines the configuration for the agent API.
 type APIConfig struct {
-	Port  string `json:"port"`               // Port where the api for for the check should listen on
-	IName string `json:"iname" toml:"iname"` // Interface name that defines the ip a check should use to reach the agent api.
-	Host  string `json:"host" toml:"host"`   // Hostname a check should use to reach the agent. Overrides the IName config param.
+	// Port where the API for the check should listen on.
+	Port string `json:"port"`
+
+	// Listener used by the agent to serve its API. It takes
+	// precedence over the Port field. It is closed by the agent.
+	Listener net.Listener
+
+	// Interface name that defines the IP a check should use to reach the agent API.
+	IName string `json:"iname" toml:"iname"`
+
+	// Host a check should use to reach the agent. Overrides the IName config param.
+	Host string `json:"host" toml:"host"`
 }
 
 // CheckConfig defines the configuration for the checks.

--- a/config/config.go
+++ b/config/config.go
@@ -74,7 +74,7 @@ type S3Writer struct {
 
 // APIConfig defines the configuration for the agent API.
 type APIConfig struct {
-	// Port where the API for the check should listen on.
+	// Port where the agent API should listen on.
 	Port string `json:"port"`
 
 	// Listener used by the agent to serve its API. It takes


### PR DESCRIPTION
Sometimes it is useful to provide a custom listener to serve the agent API. For instance, when you want to listen on a random free port (`:0`) and you need to know in advance which port will be used. This PR adds a field called `Listener` to the `APIConfig` struct. So, it is possible to specify a port via `APIConfig.Port` or a listener via `APIConfig.Listener` and the listener takes precedence over the port. 

Passing the listener as a field of the struct `APIConfig` does not seem very orthodox. However, given the current API of the agent (`agent.Run`,  `agent.RunWithQueues`), there are not many options if we don't want to introduce significant changes while keeping coherency with the current design.

BTW I noticed that `APIConfig.Port` is actually an address.

https://github.com/adevinta/vulcan-agent/blob/d9f125c2af8f5fc377d817a1ec4e9758449744d1/agent/agent.go#L173-L176

It seems a bit misleading, but I don't thing we can fix it without breaking backward compatibility.