### PR TITLE
.travis.yaml: add builds for bionic and jammy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
-dist: bionic
 language: go
+os: linux
+
+jobs:
+  include:
+    - name: bionic
+      dist: bionic
+    - name: jammy
+      dist: jammy
+
 services:
   - docker
 go:


### PR DESCRIPTION
This PR will be the base for testing this other [one](https://github.com/adevinta/vulcan-agent/pull/241) created by @alexanderkjall. I adds jobs to the travis build, so it runs the tests using both the Bionic and Jammy versions of Ubuntu.