### PR TITLE
internal/config: implement encoding.TextMarshaler also for PullPolicy

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -187,7 +187,7 @@ var pullPolicyStrings = map[PullPolicy]string{
 }
 
 // MarshalText returns string representation of a PullPolicy instance.
-func (a *PullPolicy) MarshalText() (text []byte, err error) {
+func (a PullPolicy) MarshalText() (text []byte, err error) {
 	s, err := a.String()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Implementing `PullPolicy.MarshalText` makes `PullPolicy` and
`*PullPolicy` to implement the `encoding.TextMarshaler` interface.